### PR TITLE
Stop creating internal log for docker errors

### DIFF
--- a/src/main/java/org/ballerinax/docker/DockerPlugin.java
+++ b/src/main/java/org/ballerinax/docker/DockerPlugin.java
@@ -156,7 +156,6 @@ public class DockerPlugin extends AbstractCompilerPlugin {
                         targetPath);
             } catch (DockerPluginException e) {
                 printError(e.getMessage());
-                dlog.logDiagnostic(Diagnostic.Kind.ERROR, null, e.getMessage());
                 try {
                     DockerGenUtils.deleteDirectory(targetPath);
                 } catch (DockerPluginException ignored) {


### PR DESCRIPTION
## Purpose
- Stop creating internal log for docker plugin errors
- Fixes https://github.com/ballerinax/docker/issues/103