### PR TITLE
Remove generated artifacts from sample6 test case

### DIFF
--- a/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample6Test.java
+++ b/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample6Test.java
@@ -80,5 +80,8 @@ public class Sample6Test implements SampleTest {
         DockerGenUtils.deleteDirectory(burgerTargetPath);
         DockerTestUtils.deleteDockerImage(burgerDockerImage);
         DockerTestUtils.deleteDockerImage(pizzaDockerImage);
+        DockerGenUtils.deleteDirectory(sourceDirPath + File.separator + ".ballerina");
+        DockerGenUtils.deleteDirectory(sourceDirPath + File.separator + ".gitignore");
+        DockerGenUtils.deleteDirectory(sourceDirPath + File.separator + "Ballerina.toml");
     }
 }

--- a/docker-extension/src/main/java/org/ballerinax/docker/utils/DockerGenUtils.java
+++ b/docker-extension/src/main/java/org/ballerinax/docker/utils/DockerGenUtils.java
@@ -115,9 +115,9 @@ public class DockerGenUtils {
     }
 
     /**
-     * Deletes a given directory.
+     * Recursively deletes a given directory or a file.
      *
-     * @param path path to directory
+     * @param path path to directory or file
      * @throws DockerPluginException if an error occurs while deleting
      */
     public static void deleteDirectory(String path) throws DockerPluginException {

--- a/samples/sample6/.ballerina/.gitignore
+++ b/samples/sample6/.ballerina/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
## Purpose
- Remove generated artifacts from sample6 test case.
- Removes generated ".ballerina", ".gitignore","Ballerina.toml" files after running the tests
