### PR TITLE
Docker image build for test

### DIFF
--- a/docker-extension-test/pom.xml
+++ b/docker-extension-test/pom.xml
@@ -89,6 +89,13 @@
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/commons-codec/commons-codec -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.12</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -184,11 +191,17 @@
                     <argLine>${jacoco.agent.argLine}</argLine>
                     <systemPropertyVariables>
                         <ballerina.pack>
-                            ${project.build.directory}/extracted-distributions/ballerina-zip/ballerina-${ballerina.lang.version}/bin
+                            ${project.build.directory}/extracted-distributions/ballerina-zip/ballerina-${ballerina.lang.version}/
                         </ballerina.pack>
                         <sample.dir>
                             ${project.build.directory}/../../samples
                         </sample.dir>
+                        <dockerfile>
+                            ${project.build.directory}/../../base/docker/Dockerfile
+                        </dockerfile>
+                        <docker.image.version>
+                            ${project.version}
+                        </docker.image.version>
                         <jacoco.agent.argLine>${jacoco.agent.argLine}</jacoco.agent.argLine>
                     </systemPropertyVariables>
                     <suiteXmlFiles>

--- a/docker-extension-test/pom.xml
+++ b/docker-extension-test/pom.xml
@@ -181,6 +181,26 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/test/assembly/bin.xml</descriptor>
+                            </descriptors>
+                            <finalName>ballerina-${ballerina.lang.version}</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <outputDirectory>${project.build.directory}/extracted-distributions/ballerina-zip/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <executions>
                     <execution>

--- a/docker-extension-test/pom.xml
+++ b/docker-extension-test/pom.xml
@@ -89,13 +89,11 @@
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/commons-codec/commons-codec -->
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.12</version>
+            <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/docker-extension-test/src/test/assembly/bin.xml
+++ b/docker-extension-test/src/test/assembly/bin.xml
@@ -1,0 +1,40 @@
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
+    <id>extracted-test-pack</id>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <baseDirectory>ballerina-${ballerina.lang.version}</baseDirectory>
+
+    <formats>
+        <format>zip</format>
+    </formats>
+
+    <fileSets>
+        <fileSet>
+            <directory>
+                ${project.build.directory}/extracted-distributions/ballerina-zip/ballerina-${ballerina.lang.version}/
+            </directory>
+            <outputDirectory>.</outputDirectory>
+            <fileMode>755</fileMode>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample1Test.java
+++ b/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample1Test.java
@@ -39,7 +39,7 @@ import static org.ballerinax.docker.test.utils.DockerTestUtils.getExposedPorts;
 /**
  * Test class for sample1.
  */
-public class Sample1Test implements SampleTest {
+public class Sample1Test extends SampleTest {
 
     private final Path sourceDirPath = SAMPLE_DIR.resolve("sample1");
     private final Path targetPath = sourceDirPath.resolve(ARTIFACT_DIRECTORY);
@@ -84,6 +84,6 @@ public class Sample1Test implements SampleTest {
     public void cleanUp() throws DockerPluginException, DockerTestException {
         DockerTestUtils.stopContainer(containerID);
         DockerPluginUtils.deleteDirectory(targetPath);
-        DockerTestUtils.deleteDockerImage(dockerImage);
+//        DockerTestUtils.deleteDockerImage(dockerImage);
     }
 }

--- a/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample1Test.java
+++ b/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample1Test.java
@@ -84,6 +84,6 @@ public class Sample1Test extends SampleTest {
     public void cleanUp() throws DockerPluginException, DockerTestException {
         DockerTestUtils.stopContainer(containerID);
         DockerPluginUtils.deleteDirectory(targetPath);
-//        DockerTestUtils.deleteDockerImage(dockerImage);
+        DockerTestUtils.deleteDockerImage(dockerImage);
     }
 }

--- a/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample2Test.java
+++ b/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample2Test.java
@@ -39,7 +39,7 @@ import static org.ballerinax.docker.test.utils.DockerTestUtils.getExposedPorts;
 /**
  * Test class for sample2.
  */
-public class Sample2Test implements SampleTest {
+public class Sample2Test extends SampleTest {
 
     private final Path sourceDirPath = SAMPLE_DIR.resolve("sample2");
     private final Path targetPath = sourceDirPath.resolve(ARTIFACT_DIRECTORY);

--- a/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample4Test.java
+++ b/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample4Test.java
@@ -38,7 +38,7 @@ import static org.ballerinax.docker.test.utils.DockerTestUtils.getExposedPorts;
 /**
  * Test class for sample4.
  */
-public class Sample4Test implements SampleTest {
+public class Sample4Test extends SampleTest {
 
     private final Path sourceDirPath = SAMPLE_DIR.resolve("sample4");
     private final Path targetPath = sourceDirPath.resolve(ARTIFACT_DIRECTORY);

--- a/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample5Test.java
+++ b/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample5Test.java
@@ -40,7 +40,7 @@ import static org.ballerinax.docker.test.utils.DockerTestUtils.getExposedPorts;
 /**
  * Test class for sample5.
  */
-public class Sample5Test implements SampleTest {
+public class Sample5Test extends SampleTest {
 
     private final Path sourceDirPath = SAMPLE_DIR.resolve("sample5");
     private final Path targetPath = sourceDirPath.resolve(ARTIFACT_DIRECTORY);

--- a/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample6Test.java
+++ b/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample6Test.java
@@ -37,12 +37,10 @@ import java.util.Map;
 
 import static org.ballerinax.docker.test.utils.DockerTestUtils.getExposedPorts;
 
-//import org.ballerinax.docker.test.utils.ProcessOutput;
-
 /**
  * Test class for sample6.
  */
-public class Sample6Test implements SampleTest {
+public class Sample6Test extends SampleTest {
 
     private final Path sourceDirPath = SAMPLE_DIR.resolve("sample6");
     private final Path targetDirPath = sourceDirPath.resolve("target");

--- a/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample7Test.java
+++ b/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample7Test.java
@@ -42,7 +42,7 @@ import static org.ballerinax.docker.test.utils.DockerTestUtils.getExposedPorts;
 /**
  * Test class for sample7.
  */
-public class Sample7Test implements SampleTest {
+public class Sample7Test extends SampleTest {
 
     private final Path sourceDirPath = SAMPLE_DIR.resolve("sample7");
     private final Path targetPath = sourceDirPath.resolve(ARTIFACT_DIRECTORY);

--- a/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/SampleTest.java
+++ b/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/SampleTest.java
@@ -18,27 +18,181 @@
 
 package org.ballerinax.docker.test.samples;
 
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerException;
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.ballerinax.docker.exceptions.DockerPluginException;
 import org.ballerinax.docker.test.utils.DockerTestException;
+import org.ballerinax.docker.test.utils.DockerTestUtils;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeSuite;
 
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URLEncoder;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.StringJoiner;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.ballerinax.docker.generator.DockerGenConstants.BALLERINA_BASE_IMAGE;
 
 /**
  * Base class for test cases written to test samples.
  */
-public interface SampleTest {
-    Path SAMPLE_DIR = Paths.get(FilenameUtils.separatorsToSystem(System.getProperty("sample.dir")));
-    Path CLIENT_BAL_FOLDER = Paths.get("src").resolve("test").resolve("resources").resolve("sample-clients")
+public abstract class SampleTest {
+    
+    private static final Log log = LogFactory.getLog(SampleTest.class);
+    private static final Path DOCKER_FILE = Paths.get(FilenameUtils.separatorsToSystem(
+            System.getProperty("dockerfile"))).toAbsolutePath().normalize();
+    private static final Path BALLERINA_RUNTIME_DIR = Paths.get(FilenameUtils.separatorsToSystem(
+            System.getProperty("ballerina.pack"))).toAbsolutePath();
+    private static final Path TEMP_DIR = BALLERINA_RUNTIME_DIR.getParent().resolve("tmp");
+    private static final Path DOCKER_FILE_COPY = BALLERINA_RUNTIME_DIR.getParent().resolve("Dockerfile");
+    private static final Path BALLERINA_RUNTIME_ZIP = Paths.get(BALLERINA_RUNTIME_DIR + ".zip");
+    private String dockerImage = BALLERINA_BASE_IMAGE + ":" + System.getProperty("docker.image.version");
+    protected static final Path SAMPLE_DIR = Paths.get(FilenameUtils.separatorsToSystem(
+            System.getProperty("sample.dir")));
+    protected static final Path CLIENT_BAL_FOLDER = Paths.get("src").resolve("test").resolve("resources")
+            .resolve("sample-clients")
             .toAbsolutePath();
-
+    String builtImageID = null;
+    
+    @BeforeSuite
+    public void buildDockerImage() throws IOException, DockerTestException, DockerException, InterruptedException {
+        // make temporary folder.
+        FileUtils.forceMkdir(TEMP_DIR.toFile());
+        
+        // copy pack into temporary folder.
+        FileUtils.copyDirectory(BALLERINA_RUNTIME_DIR.toFile(),
+                TEMP_DIR.resolve(BALLERINA_RUNTIME_DIR.getFileName()).toFile(), true);
+        
+        // compress the copied ballerina distribution.
+        compressFiles(TEMP_DIR, new FileOutputStream(BALLERINA_RUNTIME_ZIP.toFile()));
+        
+        // delete tmp directory
+        FileUtils.deleteQuietly(TEMP_DIR.toFile());
+        
+        // copy extracted ballerina distribution to the /docker/base directory.
+        FileUtils.copyFile(DOCKER_FILE.toFile(), DOCKER_FILE_COPY.toFile());
+        
+        // Passing build argument.
+        String ballerinaDistBuildArg = "{\"BALLERINA_DIST\":\"" +
+                                       FilenameUtils.getName(BALLERINA_RUNTIME_ZIP.toString()) + "\"}";
+        
+        CountDownLatch buildDone = new CountDownLatch(1);
+        final AtomicReference<String> errorAtomicReference = new AtomicReference<>();
+        builtImageID = DockerTestUtils.getDockerClient().build(DOCKER_FILE_COPY.getParent(), dockerImage, message -> {
+            String buildImageId = message.buildImageId();
+            String error = message.error();
+            String stream = message.stream();
+            
+            if (stream != null) {
+                log.info(stream.replaceAll("\\n", ". "));
+            }
+            
+            // when an image is built successfully.
+            if (null != buildImageId) {
+                buildDone.countDown();
+            }
+            
+            if (error != null) {
+                errorAtomicReference.set(error);
+                buildDone.countDown();
+            }
+        }, DockerClient.BuildParam.noCache(),
+                DockerClient.BuildParam.forceRm(),
+                DockerClient.BuildParam.create("buildargs", URLEncoder.encode(ballerinaDistBuildArg,
+                        Charsets.UTF_8.displayName())));
+        
+        buildDone.await();
+        String dockerErrorMsg = errorAtomicReference.get();
+        if (null != dockerErrorMsg) {
+            log.error(dockerErrorMsg);
+            Assert.fail();
+        }
+        
+        log.info("Ballerina base image built: " + builtImageID);
+        Assert.assertNotNull(DockerTestUtils.getDockerClient().inspectImage(dockerImage));
+    }
+    
     @BeforeClass
-    void compileSample() throws IOException, InterruptedException;
-
+    abstract void compileSample() throws IOException, InterruptedException;
+    
     @AfterClass
-    void cleanUp() throws DockerPluginException, InterruptedException, DockerTestException;
+    abstract void cleanUp() throws DockerPluginException, InterruptedException, DockerTestException;
+    
+    @AfterSuite
+    public void deleteDockerImage() throws DockerTestException {
+        if (null != builtImageID) {
+            log.info("Removing built ballerina base image:" + builtImageID);
+//            DockerTestUtils.deleteDockerImage(dockerImage);
+        }
+    }
+    
+    /**
+     * Compresses files.
+     *
+     * @param outputStream outputstream
+     * @return outputstream of the compressed file
+     * @throws IOException exception if an error occurrs when compressing
+     */
+    private static void compressFiles(Path dir, OutputStream outputStream) throws IOException {
+        dir = dir.resolve("");
+        ZipOutputStream zos = new ZipOutputStream(outputStream);
+        if (Files.isRegularFile(dir)) {
+            Path fileName = dir.getFileName();
+            if (fileName != null) {
+                addEntry(zos, dir, fileName.toString());
+            } else {
+                Assert.fail("Error occurred when compressing");
+            }
+        } else {
+            Stream<Path> list = Files.walk(dir);
+            Path finalDir = dir;
+            list.forEach(p -> {
+                StringJoiner joiner = new StringJoiner("/");
+                for (Path path : finalDir.relativize(p)) {
+                    joiner.add(path.toString());
+                }
+                if (Files.isRegularFile(p)) {
+                    try {
+                        addEntry(zos, p, joiner.toString());
+                    } catch (IOException e) {
+                        Assert.fail("Error occurred when compressing");
+                    }
+                }
+            });
+        }
+        zos.close();
+    }
+    
+    
+    /**
+     * Add file inside the src directory to the ZipOutputStream.
+     *
+     * @param zos      ZipOutputStream
+     * @param filePath file path of each file inside the driectory
+     * @throws IOException exception if an error occurrs when compressing
+     */
+    private static void addEntry(ZipOutputStream zos, Path filePath, String fileStr) throws IOException {
+        ZipEntry ze = new ZipEntry(fileStr);
+        zos.putNextEntry(ze);
+        Files.copy(filePath, zos);
+        zos.closeEntry();
+    }
+
 }

--- a/docker-extension-test/src/test/java/org/ballerinax/docker/test/utils/DockerTestUtils.java
+++ b/docker-extension-test/src/test/java/org/ballerinax/docker/test/utils/DockerTestUtils.java
@@ -66,6 +66,7 @@ public class DockerTestUtils {
     private static final String DISTRIBUTION_PATH = FilenameUtils.separatorsToSystem(
             System.getProperty("ballerina.pack"));
     private static final String BALLERINA_COMMAND = DISTRIBUTION_PATH +
+                                                    File.separator + "bin" +
                                                     File.separator +
                                                     (System.getProperty("os.name").toLowerCase(Locale.getDefault())
                                                              .contains("win") ? "ballerina.bat" : "ballerina");
@@ -238,8 +239,7 @@ public class DockerTestUtils {
         logOutput(process.getInputStream());
         logOutput(process.getErrorStream());
 
-        pb = new ProcessBuilder
-                (BALLERINA_COMMAND, BUILD);
+        pb = new ProcessBuilder(BALLERINA_COMMAND, BUILD);
         log.debug(EXECUTING_COMMAND + pb.command());
         pb.directory(sourceDirectory.toFile());
         Map<String, String> environment = pb.environment();

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,11 @@
                 <artifactId>commons-io</artifactId>
                 <version>${commons.io.version}</version>
             </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons.codec.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -263,6 +268,7 @@
         <ballerina.source.directory>${project.build.directory}/../src/main/ballerina</ballerina.source.directory>
         <com.fasterxml.jackson.core.annotations.version>2.9.8</com.fasterxml.jackson.core.annotations.version>
         <com.fasterxml.jackson.dataformat.yaml.version>2.9.8</com.fasterxml.jackson.dataformat.yaml.version>
+        <commons.codec.version>1.12</commons.codec.version>
         <commons.io.version>2.6</commons.io.version>
         <jackson.version>2.9.8</jackson.version>
         <maven.jacoco.plugin.version>0.8.3</maven.jacoco.plugin.version>


### PR DESCRIPTION
## Purpose
> Build the ballerina base image prior running the tests so that it wont pull the image from dockerhub. Using the image from dockerhub leads to inconsistencies with the ballerina compiled balx.

## Goals
> Increase build stability.

## Approach
> Use assembly plugin to build a zip file and then build the docker image using the java client.
