### PR TITLE
Keep gitignore file of sample6

### DIFF
--- a/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample6Test.java
+++ b/docker-extension-test/src/test/java/org/ballerinax/docker/test/samples/Sample6Test.java
@@ -127,7 +127,6 @@ public class Sample6Test extends SampleTest {
         DockerTestUtils.deleteDockerImage(burgerDockerImage);
         DockerTestUtils.deleteDockerImage(pizzaDockerImage);
         DockerPluginUtils.deleteDirectory(sourceDirPath.resolve(".ballerina"));
-        DockerPluginUtils.deleteDirectory(sourceDirPath.resolve(".gitignore"));
         DockerPluginUtils.deleteDirectory(sourceDirPath.resolve("Ballerina.toml"));
     }
 }


### PR DESCRIPTION
## Purpose
> Keep the .gitignore of sample 6 committed so that there wont be any changed files when tests run.
