### PR TITLE
OpenJDK Alpine base image: Use supported tag for recent versions.

### DIFF
--- a/base/docker/Dockerfile
+++ b/base/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 # -----------------------------------------------------------------------
 
-FROM openjdk:jre-alpine
+FROM openjdk:8-jre-alpine
 LABEL maintainer="dev@ballerina.io"
 
 # Ballerina runtime distribution filename.


### PR DESCRIPTION
## Goal
Current `openjdk:jre-alpine` linux base image does not include a "recent" version of Java. PR includes suggested change to `openjdk:8-jre-alpine` base image. Please see below for version specifics.

### Java & Alpine versions

#### Current: `openjdk:jre-alpine`

```
$ IMAGE='openjdk:jre-alpine' && docker pull "${IMAGE}" && \
    docker run --rm -it "${IMAGE}" java -version

jre-alpine: Pulling from library/openjdk
Digest: sha256:1bed44170948277881d88481ecbd07317eb7bae385560a9dd597bbfe02782766
Status: Image is up to date for openjdk:jre-alpine
openjdk version "1.8.0_171"
OpenJDK Runtime Environment (IcedTea 3.8.0) (Alpine 8.171.11-r0)
OpenJDK 64-Bit Server VM (build 25.171-b11, mixed mode)

$ docker run --rm -it "${IMAGE}" cat /etc/alpine-release
3.8.0
```

#### Suggested: `openjdk:8-jre-alpine`

```
$ IMAGE='openjdk:8-jre-alpine' && docker pull "${IMAGE}" && \
    docker run --rm -it "${IMAGE}" java -version

8-jre-alpine: Pulling from library/openjdk
Digest: sha256:22b74f5804d7ac45dfbe8e860a4bcb49d33a4a943b681c3fc78f103ff31829ea
Status: Image is up to date for openjdk:8-jre-alpine
openjdk version "1.8.0_212"
OpenJDK Runtime Environment (IcedTea 3.12.0) (Alpine 8.212.04-r0)
OpenJDK 64-Bit Server VM (build 25.212-b04, mixed mode)

$ docker run --rm -it "${IMAGE}" cat /etc/alpine-release
3.9.4
```

## Why

These Java features, introduced in Java 8u191, are important and useful in our environment:

  * [JDK-8146115: Improve docker container detection and resource configuration usage](https://www.oracle.com/technetwork/java/javase/8u191-relnotes-5032181.html#JDK-8146115)
  * [JDK-8186248: Allow more flexibility in selecting Heap % of available RAM](https://www.oracle.com/technetwork/java/javase/8u191-relnotes-5032181.html#JDK-8146115)

... and preference for 'recent' versions generally!
