### PR TITLE
Generate docker artifacts with docker import only

### DIFF
--- a/docker-extension-test/src/test/java/org/ballerinax/docker/test/NoAnnotationsModuleTest.java
+++ b/docker-extension-test/src/test/java/org/ballerinax/docker/test/NoAnnotationsModuleTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinax.docker.test;
+
+import org.ballerinax.docker.exceptions.DockerPluginException;
+import org.ballerinax.docker.test.utils.DockerTestException;
+import org.ballerinax.docker.test.utils.DockerTestUtils;
+import org.ballerinax.docker.test.utils.ProcessOutput;
+import org.ballerinax.docker.utils.DockerPluginUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.ballerinax.docker.generator.DockerGenConstants.ARTIFACT_DIRECTORY;
+import static org.ballerinax.docker.test.utils.DockerTestUtils.getExposedPorts;
+
+/**
+ * Generate docker artifacts for modules without @docker annotations.
+ */
+public class NoAnnotationsModuleTest {
+    private static final Path SOURCE_DIR_PATH = Paths.get("src", "test", "resources", "docker-tests",
+            "no_annotation_module");
+    private static final Path TARGET = SOURCE_DIR_PATH.resolve("target");
+    private static final Path CLIENT_BAL_FOLDER = Paths.get("src").resolve("test").resolve("resources")
+            .resolve("test_clients").toAbsolutePath();
+    private String containerID;
+    private String dockerImage;
+    
+    @Test(timeOut = 90000)
+    public void withAndWithoutAnnotationTest() throws IOException, InterruptedException, DockerTestException {
+        this.dockerImage = "mix_service:latest";
+        String dockerContainerName = "ballerina_docker_mix_" + this.getClass().getSimpleName().toLowerCase();
+        
+        // Stop if container is already running
+        DockerTestUtils.stopContainer(dockerContainerName);
+        
+        // Compile code
+        Assert.assertEquals(DockerTestUtils.compileBallerinaProjectModule(SOURCE_DIR_PATH, "mix_service"), 0);
+        
+        // Validate docker file
+        Path dockerfile = TARGET.resolve(ARTIFACT_DIRECTORY).resolve("mix_service").resolve("Dockerfile");
+        String dockerFileContent = new String(Files.readAllBytes(dockerfile));
+        Assert.assertTrue(dockerFileContent.contains("adduser -S -s /bin/bash -g 'ballerina' -G troupe -D ballerina"));
+        Assert.assertTrue(dockerFileContent.contains("USER ballerina"));
+        Assert.assertTrue(dockerfile.toFile().exists());
+    
+        // Validate expose ports of docker image
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 2);
+        Assert.assertTrue(ports.contains("9090/tcp"));
+        Assert.assertTrue(ports.contains("9091/tcp"));
+    
+        // Spin up a container
+        this.containerID = DockerTestUtils.createContainer(this.dockerImage, dockerContainerName,
+                Arrays.asList(9090, 9091));
+        Assert.assertTrue(DockerTestUtils.startContainer(this.containerID,
+                "[ballerina/http] started HTTP/WS listener 0.0.0.0:9090"),
+                "Service did not start properly.");
+    
+        // Send request to validate
+        ProcessOutput runOutput = DockerTestUtils.runBallerinaFile(CLIENT_BAL_FOLDER,
+                "hello_world_client_9090_9091.bal");
+        Assert.assertEquals(runOutput.getExitCode(), 0, "Error executing client.");
+        Assert.assertEquals(runOutput.getStdOutput().trim(),
+                "Hello, World from service helloWorld ! Hello, World from service helloWorld !",
+                "Unexpected service response.");
+    }
+    
+    @Test(timeOut = 90000)
+    public void withoutAnnotationTest() throws IOException, InterruptedException, DockerTestException {
+        this.dockerImage = "no_annotations:latest";
+        String dockerContainerName = "ballerina_docker_no_annotations_" + this.getClass().getSimpleName().toLowerCase();
+        
+        // Stop if container is already running
+        DockerTestUtils.stopContainer(dockerContainerName);
+        
+        // Compile code
+        Assert.assertEquals(DockerTestUtils.compileBallerinaProjectModule(SOURCE_DIR_PATH, "no_annotations"), 0);
+        
+        // Validate docker file
+        Path dockerfile = TARGET.resolve(ARTIFACT_DIRECTORY).resolve("no_annotations").resolve("Dockerfile");
+        String dockerFileContent = new String(Files.readAllBytes(dockerfile));
+        Assert.assertTrue(dockerFileContent.contains("adduser -S -s /bin/bash -g 'ballerina' -G troupe -D ballerina"));
+        Assert.assertTrue(dockerFileContent.contains("USER ballerina"));
+        Assert.assertTrue(dockerfile.toFile().exists());
+        
+        // Validate expose ports of docker image
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 2);
+        Assert.assertTrue(ports.contains("9090/tcp"));
+        Assert.assertTrue(ports.contains("9091/tcp"));
+        
+        // Spin up a container
+        this.containerID = DockerTestUtils.createContainer(this.dockerImage, dockerContainerName,
+                Arrays.asList(9090, 9091));
+        Assert.assertTrue(DockerTestUtils.startContainer(this.containerID,
+                "[ballerina/http] started HTTP/WS listener 0.0.0.0:9090"),
+                "Service did not start properly.");
+        
+        // Send request to validate
+        ProcessOutput runOutput = DockerTestUtils.runBallerinaFile(CLIENT_BAL_FOLDER,
+                "hello_world_client_9090_9091.bal");
+        Assert.assertEquals(runOutput.getExitCode(), 0, "Error executing client.");
+        Assert.assertEquals(runOutput.getStdOutput().trim(),
+                "Hello, World from service helloWorld ! Hello, World from service helloWorld !",
+                "Unexpected service response.");
+    }
+    
+    @AfterMethod
+    public void cleanUp() throws DockerPluginException {
+        DockerTestUtils.stopContainer(this.containerID);
+        DockerPluginUtils.deleteDirectory(TARGET);
+        DockerTestUtils.deleteDockerImage(this.dockerImage);
+    }
+}

--- a/docker-extension-test/src/test/java/org/ballerinax/docker/test/NoAnnotationsTest.java
+++ b/docker-extension-test/src/test/java/org/ballerinax/docker/test/NoAnnotationsTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinax.docker.test;
+
+import org.ballerinax.docker.exceptions.DockerPluginException;
+import org.ballerinax.docker.test.utils.DockerTestException;
+import org.ballerinax.docker.test.utils.DockerTestUtils;
+import org.ballerinax.docker.test.utils.ProcessOutput;
+import org.ballerinax.docker.utils.DockerPluginUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.ballerinax.docker.generator.DockerGenConstants.ARTIFACT_DIRECTORY;
+import static org.ballerinax.docker.test.utils.DockerTestUtils.getExposedPorts;
+
+/**
+ * Generate docker artifacts without @docker annotations.
+ */
+public class NoAnnotationsTest {
+    private static final Path SOURCE_DIR_PATH = Paths.get("src", "test", "resources", "docker-tests");
+    private static final Path TARGET_PATH = SOURCE_DIR_PATH.resolve(ARTIFACT_DIRECTORY);
+    private static final Path CLIENT_BAL_FOLDER = Paths.get("src").resolve("test").resolve("resources")
+            .resolve("test_clients").toAbsolutePath();
+    private String containerID;
+    private String dockerImage;
+    private String jarName;
+    
+    @Test(timeOut = 90000)
+    public void serviceWithNoAnnotationTest() throws IOException, InterruptedException, DockerTestException {
+        this.dockerImage = "no_annotation_service:latest";
+        this.jarName = "no_annotation_service.jar";
+        String dockerContainerName = "ballerina_docker_svc_" + this.getClass().getSimpleName().toLowerCase();
+        
+        // Stop if container is already running
+        DockerTestUtils.stopContainer(dockerContainerName);
+        
+        // Compile code
+        Assert.assertEquals(DockerTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "no_annotation_service.bal")
+                .getExitCode(), 0);
+    
+        // Validate docker file
+        Path dockerfile = TARGET_PATH.resolve("Dockerfile");
+        String dockerFileContent = new String(Files.readAllBytes(dockerfile));
+        Assert.assertTrue(dockerFileContent.contains("adduser -S -s /bin/bash -g 'ballerina' -G troupe -D ballerina"));
+        Assert.assertTrue(dockerFileContent.contains("USER ballerina"));
+        Assert.assertTrue(dockerfile.toFile().exists());
+    
+        // Validate expose ports of docker image
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9090/tcp");
+    
+        // Spin up a container
+        this.containerID = DockerTestUtils.createContainer(this.dockerImage, dockerContainerName);
+        Assert.assertTrue(DockerTestUtils.startContainer(this.containerID,
+                "[ballerina/http] started HTTP/WS listener 0.0.0.0:9090"),
+                "Service did not start properly.");
+    
+        // Send request to validate
+        ProcessOutput runOutput = DockerTestUtils.runBallerinaFile(CLIENT_BAL_FOLDER, "hello_world_client.bal");
+        Assert.assertEquals(runOutput.getExitCode(), 0, "Error executing client.");
+        Assert.assertEquals(runOutput.getStdOutput(), "Hello, World!", "Unexpected service response.");
+    }
+    
+    @Test(timeOut = 90000)
+    public void listenerWithNoAnnotationTest() throws IOException, InterruptedException, DockerTestException {
+        this.dockerImage = "no_annotation_listener:latest";
+        this.jarName = "no_annotation_listener.jar";
+        String dockerContainerName = "ballerina_docker_lstnr_" + this.getClass().getSimpleName().toLowerCase();
+        
+        // Stop if container is already running
+        DockerTestUtils.stopContainer(dockerContainerName);
+        
+        // Compile code
+        Assert.assertEquals(DockerTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "no_annotation_listener.bal")
+                .getExitCode(), 0);
+        
+        // Validate docker file
+        Path dockerfile = TARGET_PATH.resolve("Dockerfile");
+        String dockerFileContent = new String(Files.readAllBytes(dockerfile));
+        Assert.assertTrue(dockerFileContent.contains("adduser -S -s /bin/bash -g 'ballerina' -G troupe -D ballerina"));
+        Assert.assertTrue(dockerFileContent.contains("USER ballerina"));
+        Assert.assertTrue(dockerfile.toFile().exists());
+        
+        // Validate expose ports of docker image
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 1);
+        Assert.assertEquals(ports.get(0), "9090/tcp");
+        
+        // Spin up a container
+        this.containerID = DockerTestUtils.createContainer(this.dockerImage, dockerContainerName);
+        Assert.assertTrue(DockerTestUtils.startContainer(this.containerID,
+                "[ballerina/http] started HTTP/WS listener 0.0.0.0:9090"),
+                "Service did not start properly.");
+        
+        // Send request to validate
+        ProcessOutput runOutput = DockerTestUtils.runBallerinaFile(CLIENT_BAL_FOLDER, "hello_world_client.bal");
+        Assert.assertEquals(runOutput.getExitCode(), 0, "Error executing client.");
+        Assert.assertEquals(runOutput.getStdOutput().trim(), "Hello, World!", "Unexpected service response.");
+    }
+    
+    @Test(timeOut = 90000)
+    public void mainWithNoAnnotationTest() throws IOException, InterruptedException, DockerTestException {
+        this.dockerImage = "no_annotation_main:latest";
+        this.jarName = "no_annotation_main.jar";
+        String dockerContainerName = "ballerina_docker_main_" + this.getClass().getSimpleName().toLowerCase();
+        
+        // Stop if container is already running
+        DockerTestUtils.stopContainer(dockerContainerName);
+        
+        // Compile code
+        Assert.assertEquals(DockerTestUtils.compileBallerinaFile(SOURCE_DIR_PATH, "no_annotation_main.bal")
+                .getExitCode(), 0);
+        
+        // Validate docker file
+        Path dockerfile = TARGET_PATH.resolve("Dockerfile");
+        String dockerFileContent = new String(Files.readAllBytes(dockerfile));
+        Assert.assertTrue(dockerFileContent.contains("adduser -S -s /bin/bash -g 'ballerina' -G troupe -D ballerina"));
+        Assert.assertTrue(dockerFileContent.contains("USER ballerina"));
+        Assert.assertTrue(dockerfile.toFile().exists());
+        
+        // Validate expose ports of docker image
+        List<String> ports = getExposedPorts(this.dockerImage);
+        Assert.assertEquals(ports.size(), 0);
+        
+        // Spin up a container
+        this.containerID = DockerTestUtils.createContainer(this.dockerImage, dockerContainerName);
+        Assert.assertTrue(DockerTestUtils.startContainer(this.containerID, "Hello, World!"),
+                "Main function did not run.");
+    }
+    
+    @AfterMethod
+    public void cleanUp() throws DockerPluginException, IOException {
+        DockerTestUtils.stopContainer(this.containerID);
+        DockerPluginUtils.deleteDirectory(TARGET_PATH);
+        DockerTestUtils.deleteDockerImage(this.dockerImage);
+        Files.deleteIfExists(SOURCE_DIR_PATH.resolve(this.jarName));
+    }
+}

--- a/docker-extension-test/src/test/java/org/ballerinax/docker/test/NoImageBuildTest.java
+++ b/docker-extension-test/src/test/java/org/ballerinax/docker/test/NoImageBuildTest.java
@@ -60,7 +60,8 @@ public class NoImageBuildTest {
     }
     
     @AfterClass
-    public void cleanUp() throws DockerPluginException {
+    public void cleanUp() throws DockerPluginException, IOException {
         DockerPluginUtils.deleteDirectory(targetPath);
+        Files.deleteIfExists(sourceDirPath.resolve("build_image_false.jar"));
     }
 }

--- a/docker-extension-test/src/test/resources/docker-tests/.gitignore
+++ b/docker-extension-test/src/test/resources/docker-tests/.gitignore
@@ -1,0 +1,3 @@
+*.jar
+Dockerfile
+/docker

--- a/docker-extension-test/src/test/resources/docker-tests/.gitignore
+++ b/docker-extension-test/src/test/resources/docker-tests/.gitignore
@@ -1,3 +1,5 @@
 *.jar
 Dockerfile
 /docker
+/target
+Ballerina.lock

--- a/docker-extension-test/src/test/resources/docker-tests/no_annotation_listener.bal
+++ b/docker-extension-test/src/test/resources/docker-tests/no_annotation_listener.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/docker as _;
+
+listener http:Listener helloWorldEP = new(9090);
+
+@http:ServiceConfig {
+      basePath: "/helloWorld"
+}
+service helloWorld on helloWorldEP {
+    resource function sayHello (http:Caller outboundEP, http:Request request) {
+        http:Response response = new;
+        response.setTextPayload("Hello, World! \n");
+        var responseResult = outboundEP->respond(response);
+        if (responseResult is error) {
+            log:printError("error responding back to client.", responseResult);
+        }
+    }
+}

--- a/docker-extension-test/src/test/resources/docker-tests/no_annotation_main.bal
+++ b/docker-extension-test/src/test/resources/docker-tests/no_annotation_main.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/docker as _;
+import ballerina/io;
+
+public function main() {
+    io:println("Hello, World!");
+}

--- a/docker-extension-test/src/test/resources/docker-tests/no_annotation_module/Ballerina.toml
+++ b/docker-extension-test/src/test/resources/docker-tests/no_annotation_module/Ballerina.toml
@@ -1,0 +1,3 @@
+[project]
+org-name = "paul"
+version = "0.1.0"

--- a/docker-extension-test/src/test/resources/docker-tests/no_annotation_module/Ballerina.toml
+++ b/docker-extension-test/src/test/resources/docker-tests/no_annotation_module/Ballerina.toml
@@ -1,3 +1,3 @@
 [project]
-org-name = "paul"
+org-name = "panda"
 version = "0.1.0"

--- a/docker-extension-test/src/test/resources/docker-tests/no_annotation_module/src/mix_service/no_annotation.bal
+++ b/docker-extension-test/src/test/resources/docker-tests/no_annotation_module/src/mix_service/no_annotation.bal
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/docker;
+
+@http:ServiceConfig {
+    basePath: "/helloWorld"
+}
+@docker:Config {}
+service helloWorld on new http:Listener(9090) {
+    resource function sayHello(http:Caller outboundEP, http:Request request) {
+        http:Response response = new;
+        response.setTextPayload("Hello, World from service helloWorld ! \n");
+        var responseResult = outboundEP->respond(response);
+        if (responseResult is error) {
+            log:printError("error responding back to client.", responseResult);
+        }
+    }
+}

--- a/docker-extension-test/src/test/resources/docker-tests/no_annotation_module/src/mix_service/with_annotation.bal
+++ b/docker-extension-test/src/test/resources/docker-tests/no_annotation_module/src/mix_service/with_annotation.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/docker as _;
+
+@http:ServiceConfig {
+    basePath: "/helloWorld"
+}
+service helloWorldNoAnnotation on new http:Listener(9091) {
+    resource function sayHello(http:Caller outboundEP, http:Request request) {
+        http:Response response = new;
+        response.setTextPayload("Hello, World from service helloWorld ! \n");
+        var responseResult = outboundEP->respond(response);
+        if (responseResult is error) {
+            log:printError("error responding back to client.", responseResult);
+        }
+    }
+}

--- a/docker-extension-test/src/test/resources/docker-tests/no_annotation_module/src/no_annotations/no_annotation_9090.bal
+++ b/docker-extension-test/src/test/resources/docker-tests/no_annotation_module/src/no_annotations/no_annotation_9090.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/docker as _;
+
+@http:ServiceConfig {
+    basePath: "/helloWorld"
+}
+service helloWorld1 on new http:Listener(9090) {
+    resource function sayHello(http:Caller outboundEP, http:Request request) {
+        http:Response response = new;
+        response.setTextPayload("Hello, World from service helloWorld ! \n");
+        var responseResult = outboundEP->respond(response);
+        if (responseResult is error) {
+            log:printError("error responding back to client.", responseResult);
+        }
+    }
+}

--- a/docker-extension-test/src/test/resources/docker-tests/no_annotation_module/src/no_annotations/no_annotation_9091.bal
+++ b/docker-extension-test/src/test/resources/docker-tests/no_annotation_module/src/no_annotations/no_annotation_9091.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/docker as _;
+
+@http:ServiceConfig {
+    basePath: "/helloWorld"
+}
+service helloWorld2 on new http:Listener(9091) {
+    resource function sayHello(http:Caller outboundEP, http:Request request) {
+        http:Response response = new;
+        response.setTextPayload("Hello, World from service helloWorld ! \n");
+        var responseResult = outboundEP->respond(response);
+        if (responseResult is error) {
+            log:printError("error responding back to client.", responseResult);
+        }
+    }
+}

--- a/docker-extension-test/src/test/resources/docker-tests/no_annotation_service.bal
+++ b/docker-extension-test/src/test/resources/docker-tests/no_annotation_service.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/docker as _;
+
+service helloWorld on new http:Listener(9090) {
+    // Resource functions are invoked with the HTTP caller and the incoming request as arguments.
+    resource function sayHello(http:Caller caller, http:Request req) {
+        // Send a response back to the caller.
+        var result = caller->respond("Hello, World!");
+        if (result is error) {
+            log:printError("Error sending response", result);
+        }
+    }
+}

--- a/docker-extension-test/src/test/resources/test_clients/hello_world_client.bal
+++ b/docker-extension-test/src/test/resources/test_clients/hello_world_client.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/http;
+
+public function main(string... args) {
+    http:Client helloWorldEP = new("http://" + <@untainted> args[0] + ":9090");
+    var response = helloWorldEP->get("/helloWorld/sayHello");
+    if (response is http:Response) {
+        io:println(response.getTextPayload());
+    } else {
+        io:println(response);
+    }
+}

--- a/docker-extension-test/src/test/resources/test_clients/hello_world_client_9090_9091.bal
+++ b/docker-extension-test/src/test/resources/test_clients/hello_world_client_9090_9091.bal
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/http;
+
+public function main(string... args) {
+    http:Client helloWorldEP1 = new("http://" + <@untainted> args[0] + ":9090");
+    var response1 = helloWorldEP1->get("/helloWorld/sayHello");
+    if (response1 is http:Response) {
+        io:println(response1.getTextPayload());
+    } else {
+        io:println(response1);
+    }
+
+    http:Client helloWorldEP2 = new("http://" + <@untainted> args[0] + ":9091");
+    var response2 = helloWorldEP2->get("/helloWorld/sayHello");
+    if (response2 is http:Response) {
+        io:println(response2.getTextPayload());
+    } else {
+        io:println(response2);
+    }
+}

--- a/docker-extension-test/src/test/resources/testng.xml
+++ b/docker-extension-test/src/test/resources/testng.xml
@@ -36,6 +36,8 @@
     <test name="ballerinax-docker-integration-tests" parallel="false">
         <classes>
             <class name="org.ballerinax.docker.test.NoImageBuildTest"/>
+            <class name="org.ballerinax.docker.test.NoAnnotationsTest"/>
+            <class name="org.ballerinax.docker.test.NoAnnotationsModuleTest"/>
         </classes>
     </test>
 

--- a/docker-extension/src/main/java/org/ballerinax/docker/DockerPlugin.java
+++ b/docker-extension/src/main/java/org/ballerinax/docker/DockerPlugin.java
@@ -103,10 +103,8 @@ public class DockerPlugin extends AbstractCompilerPlugin {
                         .map(tln -> (ServiceNode) tln)
                         .collect(Collectors.toList());
         
-                // Generate artifacts for services with 'new listener()'
-                serviceNodes.stream()
-                        .filter(sn -> sn.getAttachedExprs().stream().anyMatch(aex -> aex instanceof BLangTypeInit))
-                        .forEach(sn -> process(sn, Collections.singletonList(createAnnotation("Config"))));
+                // Generate artifacts for services for all services
+                serviceNodes.forEach(sn -> process(sn, Collections.singletonList(createAnnotation("Config"))));
         
                 // Get the variable names of the listeners attached to services
                 List<String> listenerNamesToExpose = serviceNodes.stream()

--- a/docker-extension/src/main/java/org/ballerinax/docker/utils/DockerPluginUtils.java
+++ b/docker-extension/src/main/java/org/ballerinax/docker/utils/DockerPluginUtils.java
@@ -18,8 +18,12 @@
 
 package org.ballerinax.docker.utils;
 
+import org.ballerinalang.model.tree.AnnotationAttachmentNode;
+import org.ballerinalang.model.tree.IdentifierNode;
 import org.ballerinax.docker.exceptions.DockerPluginException;
 import org.ballerinax.docker.generator.DockerGenConstants;
+import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
+import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
 
 import java.io.File;
@@ -127,5 +131,20 @@ public class DockerPluginUtils {
             }
         }
         return value;
+    }
+    
+    /**
+     * Create an annotation node.
+     *
+     * @param annotationName Name of the annotation node.
+     * @return The created node.
+     */
+    public static AnnotationAttachmentNode createAnnotation(String annotationName) {
+        AnnotationAttachmentNode configAnnotation = new BLangAnnotationAttachment();
+        IdentifierNode configIdentifier = new BLangIdentifier();
+        configIdentifier.setValue(annotationName);
+        configAnnotation.setAnnotationName(configIdentifier);
+        configAnnotation.setExpression(new BLangRecordLiteral());
+        return configAnnotation;
     }
 }


### PR DESCRIPTION
## Purpose
> $subject. Resolves https://github.com/ballerinax/docker/issues/367

With this change it is possible to generate Dockerfile and docker images by only including the docker import as follows:
```ballerina
import ballerina/docker as _;
```

Example: 
```ballerina
import ballerina/http;
import ballerina/log;
import ballerina/docker as _;

listener http:Listener helloWorldEP = new(9090);

@http:ServiceConfig {
      basePath: "/helloWorld"
}
service helloWorld on helloWorldEP {
    resource function sayHello (http:Caller outboundEP, http:Request request) {
        http:Response response = new;
        response.setTextPayload("Hello, World! \n");
        var responseResult = outboundEP->respond(response);
        if (responseResult is error) {
            log:printError("error responding back to client.", responseResult);
        }
    }
}
```